### PR TITLE
Add TCX conversion to CLI

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ function* convert(data) {
     yield* tj.kmlGen(parser.parseFromString(data));
   } else if (snippet.includes("<gpx")) {
     yield* tj.gpxGen(parser.parseFromString(data));
+  } else if (snippet.includes("<TrainingCenterDatabase")) {
+    yield* tj.tcxGen(parser.parseFromString(data));
   } else {
     throw new Error("Could not detect file format of an input");
   }


### PR DESCRIPTION
This adds TCX conversion to the CLI. In an example TCX file I tested with, the first two lines were
```xml
<?xml version="1.0" encoding="UTF-8"?>
<TrainingCenterDatabase xsi:schemaLocation="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2
...
```
It seems likely that `<TrainingCenterDatabase` will always be in the first 200 characters, but I don't know the format well enough to know for sure.